### PR TITLE
Terrain Tiles Fixes

### DIFF
--- a/terrain-tiles/README.md
+++ b/terrain-tiles/README.md
@@ -8,7 +8,12 @@ Contains terrain tiles in the N047E011 region. These tiles are made to be used w
 
 1.) Include the terrain tiles in your maps list of sources.
 
-    terrain: {
+    terrain_source: {
+    	type: 'raster-dem',
+    	url: 'https://demotiles.maplibre.org/terrain-tiles/tiles.json',
+    	tileSize: 256
+    },
+    hillshade_source: {
     	type: 'raster-dem',
     	url: 'https://demotiles.maplibre.org/terrain-tiles/tiles.json',
     	tileSize: 256
@@ -17,7 +22,7 @@ Contains terrain tiles in the N047E011 region. These tiles are made to be used w
 2.) Use the terrain tile source for 3d terrain in you style.
 
     terrain: {
-    	source:  'terrain',
+    	source:  'terrain_source',
     	exaggeration:  1
     }
 
@@ -26,9 +31,9 @@ Contains terrain tiles in the N047E011 region. These tiles are made to be used w
     {
     	id:  'hills',
     	type:  'hillshade',
-    	source:  'terrain',
+    	source:  'hillshade_source',
     	layout: {'visibility':  'visible'},
-    	paint: {'hillshade-exaggeration':  0.33}
+    	paint: {'hillshade-shadow-color':'#473B24'}
     }
   
 4.) With all of these combined, the style should look something like this.
@@ -44,7 +49,12 @@ Contains terrain tiles in the N047E011 region. These tiles are made to be used w
 				attribution:  '&copy; OpenStreetMap Contributors',
 				maxzoom:  19
 			},
-    		terrain: {
+    		terrain_source: {
+				type:  'raster-dem',
+				url:  'https://demotiles.maplibre.org/terrain-tiles/tiles.json',
+				tileSize:  256
+			},
+    		hillshade_source: {
 				type:  'raster-dem',
 				url:  'https://demotiles.maplibre.org/terrain-tiles/tiles.json',
 				tileSize:  256
@@ -59,13 +69,13 @@ Contains terrain tiles in the N047E011 region. These tiles are made to be used w
     		{
     			id:  'hills',
 				type:  'hillshade',
-				source:  'terrain',
+				source:  'hillshade_source',
 				layout: {'visibility':  'visible'},
-				paint: {'hillshade-exaggeration':  0.33}
+				paint: {'hillshade-shadow-color':'#473B24'}
 			}
 		],
 		terrain: {
-			source:  'terrain',
+			source:  'terrain_source',
 			exaggeration:  1
 		}
     }

--- a/terrain-tiles/tiles.json
+++ b/terrain-tiles/tiles.json
@@ -1,6 +1,6 @@
 {
     "tiles": [
-        "https://maplibre.org/demotiles/terrain-tiles/{z}/{x}/{y}.png"
+        "https://raw.githubusercontent.com/maplibre/demotiles/gh-pages/terrain-tiles/{z}/{x}/{y}.png"
     ],
     "name": "jaxa_terrainrgb_N047E011",
     "format": "png",


### PR DESCRIPTION
After testing the terrain tiles I have found some issues. This PR should fix them.

1.) Update the README to indicate two source should be used for hillshade and terrain. 
2.) Remove hillshade-exaggeration since with separate sources the hillshade is not so dark (it was very dark before and had to be left scaled back)
3.) Update the tile.json to point to github. This gets around a CORS error I got when i tried to use the tiles on stackblitz

Updated demo: https://stackblitz.com/edit/web-platform-xyojdp