### PR TITLE
Use `demotiles.maplibre.org` subdomain to fix CORS problems

### DIFF
--- a/terrain-tiles/tiles.json
+++ b/terrain-tiles/tiles.json
@@ -1,6 +1,6 @@
 {
     "tiles": [
-        "https://raw.githubusercontent.com/maplibre/demotiles/gh-pages/terrain-tiles/{z}/{x}/{y}.png"
+        "https://demotiles.maplibre.org/terrain-tiles/{z}/{x}/{y}.png"
     ],
     "name": "jaxa_terrainrgb_N047E011",
     "format": "png",


### PR DESCRIPTION
@acalcutt something like this should still avoid CORS problems. Should we try this out?