### PR TITLE
Update MapLibre GL JS version.  Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,27 @@
 # MapLibre sample world map - demotiles
 
-This is the sample vector map displayed on the frontpage of www.maplibre.org - used in the helloworld examples and CI tests of @MapLibre organization.
+This is the sample vector map displayed on the frontpage of https://maplibre.org - used in the helloworld examples and CI tests of @MapLibre organization.
 
 It demonstrates the usage of simple vector tiles with the *MapLibre World* map style.
 
 Hosted as static files directly on GitHub Pages, serverless, no keys, runs offline as well.
 
+## Demo
 
-Live preview https://demotiles.maplibre.org/
+See the live preview at https://demotiles.maplibre.org.  You can also access the style as JSON for testing in mobile or other style tools.
+
+| Style | Live Demo | `style.json`
+| :--- | :--- | :---
+| MapLibre Demo | https://demotiles.maplibre.org | https://demotiles.maplibre.org/style.json
+| OSM Bright | https://demotiles.maplibre.org/tiles-omt | https://demotiles.maplibre.org/styles/osm-bright-gl-style/style.json
+| Terrain,</br>centered around Innsbruck, Austria | https://demotiles.maplibre.org/terrain-tiles | https://demotiles.maplibre.org/styles/osm-bright-gl-terrain/style.json
+
+### Tiles
 
 The MBTiles can be downloaded in the [releases](https://github.com/maplibre/demotiles/releases).
 For offline use you can download the [.zip](https://github.com/maplibre/demotiles/archive/refs/heads/gh-pages.zip) including the font and viewer.
+
+### Contributors
 
 Kindly provided by [MapTiler](https://www.maptiler.com/) team (@klokan, @nbozon, @petr-pokorny-1, @tomasklanica).
 

--- a/index.html
+++ b/index.html
@@ -2,8 +2,8 @@
 <html>
 <head>
   <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
-  <script src="https://cdn.maptiler.com/maplibre-gl-js/v1.14.0/maplibre-gl.js"></script>
-  <link href="https://cdn.maptiler.com/maplibre-gl-js/v1.14.0/maplibre-gl.css" rel="stylesheet" />
+  <script src='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js'></script>
+  <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
   <style>
     #map {position: absolute; top: 0; right: 0; bottom: 0; left: 0;}
   </style>


### PR DESCRIPTION
This PR:

1.  Updates the latest MapLibre GL JS version that  is served from the demo page:  https://demotiles.maplibre.org/
2. adds to the README a table of demo styles and the style.json for each
3. See live preview of the README — https://github.com/roblabs/demotiles/tree/update/latest_version_readme#demo

*Summary of the change to the README*
![image](https://user-images.githubusercontent.com/118112/215175015-45b2fda1-349d-4b99-b36e-c6df357a2513.jpeg)
