### PR TITLE
Update depreciated 'a.tile.openstreetmap.org' url in terrain example.

### DIFF
--- a/terrain-tiles/README.md
+++ b/terrain-tiles/README.md
@@ -42,7 +42,7 @@ Contains terrain tiles in the N047E011 region. These tiles are made to be used w
     	sources: {
     		osm: {
 				type:  'raster',
-				tiles: ['https://a.tile.openstreetmap.org/{z}/{x}/{y}.png'],
+				tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
 				tileSize:  256,
 				attribution:  '&copy; OpenStreetMap Contributors',
 				maxzoom:  19


### PR DESCRIPTION
Remove a.tile.openstreetmap.org url which has been deprecated. see https://github.com/openstreetmap/operations/issues/737