### PR TITLE
Add Cloudflare Worker to serve PMTiles from R2

### DIFF
--- a/.github/workflows/sync-pmtiles-to-r2.yml
+++ b/.github/workflows/sync-pmtiles-to-r2.yml
@@ -1,0 +1,26 @@
+name: Sync PMTiles to R2
+
+on:
+  push:
+    branches: [gh-pages]
+    paths: [pmtiles/**/*.pmtiles]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Upload changed PMTiles to R2
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          npx wrangler@latest r2 object put demotiles-pmtiles/pmtiles/vector/world.pmtiles \
+            --file pmtiles/vector/world.pmtiles --remote
+          npx wrangler@latest r2 object put demotiles-pmtiles/pmtiles/raster/watercolor.pmtiles \
+            --file pmtiles/raster/watercolor.pmtiles --remote
+          npx wrangler@latest r2 object put demotiles-pmtiles/pmtiles/raster/imagery.pmtiles \
+            --file pmtiles/raster/imagery.pmtiles --remote
+          npx wrangler@latest r2 object put demotiles-pmtiles/pmtiles/raster/terrain.pmtiles \
+            --file pmtiles/raster/terrain.pmtiles --remote

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store.pbf
+.wrangler/

--- a/README.md
+++ b/README.md
@@ -20,17 +20,12 @@ It demonstrates the usage of simple vector tiles with the *MapLibre World* map s
 
 Hosted as static files directly on GitHub Pages, serverless, no keys, runs offline as well.
 
+Country polygons are from [Natural Earth Data](https://www.naturalearthdata.com/).
+
 The MBTiles can be downloaded in the [releases](https://github.com/maplibre/demotiles/releases).
 For offline use you can download the [.zip](https://github.com/maplibre/demotiles/archive/refs/heads/gh-pages.zip) including the font and viewer.
 
 ![maplibre-world-map-style](https://user-images.githubusercontent.com/59284/118267966-117aa100-b4bd-11eb-8824-430cbe674191.png)
-
-## World countries vector tiles
-
-The map uses a lightweight vector tileset to color and label the world countries. Country polygons are from [Natural Earth Data](https://www.naturalearthdata.com/).
-The shapefiles were converted into vector tiles using the [MapTiler Desktop](https://www.maptiler.com/) software, which generates similar .pbf tile directory structure as present, as well as GeoPackage MVT or MBTiles file output.
-
-![maptiler-desktop-generate-vector-tiles](https://user-images.githubusercontent.com/59284/118269170-ac27af80-b4be-11eb-93c9-188c578b914e.gif)
 
 The resulting maplibre.mbtiles is available from this repo (pbf, z0-6, 4Mb).
 
@@ -68,11 +63,11 @@ The [number-hillshade](debug-tiles/number-hillshade) tiles render the zoom level
 
 The [terrain-ruffles](debug-tiles/terrain-ruffles) tiles contain a ruffle around the border, which helps visualize bouundaries between loaded raster tiles.
 
-## PMTiles
+## MapLibre PMTiles
 
 The [pmtiles/](pmtiles/) directory contains PMTiles archives you can reference directly or download for your own testing. Archives are split into `/vector` and `/raster` folders because each archive holds a single tile type.
 
-Please note: MapLibre style spec treats the two raster source types differently depending on the layer: [`raster-dem`](https://maplibre.org/maplibre-style-spec/sources/#raster-dem) decodes pixel values as terrain elevation (hillshade, 3D terrain), while [`raster`](https://maplibre.org/maplibre-style-spec/sources/#raster) renders the raw pixels directly.
+MapLibre style spec treats the two raster source types differently depending on the layer: [`raster-dem`](https://maplibre.org/maplibre-style-spec/sources/#raster-dem) decodes pixel values as terrain elevation (hillshade, 3D terrain), while [`raster`](https://maplibre.org/maplibre-style-spec/sources/#raster) renders the raw pixels directly.
 
 See the [Protomaps MapLibre docs](https://docs.protomaps.com/pmtiles/maplibre) for GL JS setup (MapLibre Native has built-in PMTiles support and does not require the JS protocol plugin).
 
@@ -100,6 +95,8 @@ Previews: [imagery.html](pmtiles/raster/imagery.html) · [watercolor.html](pmtil
 
 **Coverage:** all three are tight to the core box `[9,46,15,49]`, except the watercolor archive, whose low zooms (z0–7) span a wider `[0,41,23,56]`; panning past z7 outside the core box can show overzoomed tiles.
 
+[!NOTE] The `.pmtiles` files are served from a private R2 bucket via a Cloudflare Worker (`worker/`) rather than GitHub Pages directly; Cloudflare's CDN corrupts HTTP Range requests on GitHub Pages-hosted files, which breaks PMTiles fetching.
+
 ### Licensing
 
 Please preserve the licenses for all source data, embedded in each archive's metadata and shown on-map:
@@ -113,7 +110,7 @@ Please preserve the licenses for all source data, embedded in each archive's met
 
 the [PMTiles Raster](#raster-innsbruck-austria) demos were kindly donated by [Stephanie May](https://github.com/mizmay), combining terrain from [Mapterhorn](https://mapterhorn.com/), [Sentinel-2 cloudless](https://s2maps.eu) imagery by [EOX](https://eox.at), [Stamen Design](https://stamen.com) watercolor archived by [Cooper Hewitt](https://watercolormaps.collection.cooperhewitt.org), and an OpenMapTiles overlay from the [OSM US Tile Service](https://tiles.openstreetmap.us/). See [Licensing](#licensing) for terms.
 
-the [MapLibre World](#maplibre-world-demo-map) demo was kindly provided by the [MapTiler](https://www.maptiler.com/) team ([@klokan](https://github.com/klokan), [@nbozon](https://github.com/nbozon), [@petr-pokorny-1](https://github.com/petr-pokorny-1), [@tomasklanica](https://github.com/tomasklanica)). 
+the [MapLibre World](#maplibre-world-demo-map) demo was kindly provided by the [MapTiler](https://www.maptiler.com/) team ([@klokan](https://github.com/klokan), [@nbozon](https://github.com/nbozon), [@petr-pokorny-1](https://github.com/petr-pokorny-1), [@tomasklanica](https://github.com/tomasklanica)).
 
 the [Terrain](terrain-tiles) and [OpenMapTiles](tiles-omt) demos were provided by [@acalcutt](https://github.com/acalcutt) with styles based on [OSM Bright](https://github.com/openmaptiles/osm-bright-gl-style).
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ Please preserve the licenses for all source data, embedded in each archive's met
 - **Terrain:** © [Mapterhorn](https://mapterhorn.com/attribution), from ESA Copernicus DEM.
 - **Vector overlay:** © [OpenStreetMap](https://www.openstreetmap.org/copyright) contributors ([ODbL](https://opendatacommons.org/licenses/odbl/)) via the [OSM US Tile Service](https://tiles.openstreetmap.us/) (OpenMapTiles).
 
+## Infrastructure
+
+The `.pmtiles` files are served from a private R2 bucket via the Cloudflare Worker in [`worker/`](worker/), which handles HTTP Range requests that Cloudflare's CDN would otherwise corrupt when serving from GitHub Pages.
+
 ## Contributors
 
 the [PMTiles Raster](#raster-innsbruck-austria) demos were kindly donated by [Stephanie May](https://github.com/mizmay), combining terrain from [Mapterhorn](https://mapterhorn.com/), [Sentinel-2 cloudless](https://s2maps.eu) imagery by [EOX](https://eox.at), [Stamen Design](https://stamen.com) watercolor archived by [Cooper Hewitt](https://watercolormaps.collection.cooperhewitt.org), and an OpenMapTiles overlay from the [OSM US Tile Service](https://tiles.openstreetmap.us/). See [Licensing](#licensing) for terms.

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -1,0 +1,52 @@
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    // Pass everything that isn't a .pmtiles file straight through to GitHub Pages
+    // (demo HTML, screenshots, etc. under /pmtiles/*).
+    if (!url.pathname.endsWith(".pmtiles")) {
+      return fetch(request);
+    }
+
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      return new Response("Method Not Allowed", { status: 405 });
+    }
+
+    // R2 key mirrors the path, e.g. "pmtiles/vector/world.pmtiles"
+    const key = url.pathname.replace(/^\/+/, "");
+
+    const object = await env.BUCKET.get(key, {
+      range: request.headers,   // honor the client's Range request natively
+      onlyIf: request.headers,  // honor If-Range / If-None-Match for caching
+    });
+
+    if (object === null) {
+      return new Response("Not Found", { status: 404 });
+    }
+
+    const headers = new Headers();
+    object.writeHttpMetadata(headers);
+    headers.set("etag", object.httpEtag);     // strong ETag passed through unchanged
+    headers.set("Accept-Ranges", "bytes");
+    headers.set("Access-Control-Allow-Origin", "*");
+    headers.set("Cache-Control", "public, max-age=86400");
+
+    // No body => conditional request matched (304).
+    if (!("body" in object) || object.body === undefined) {
+      return new Response(null, { status: 304, headers });
+    }
+
+    const isRange = object.range && request.headers.has("range");
+    if (isRange) {
+      const offset = object.range.offset ?? 0;
+      const length = object.range.length ?? (object.size - offset);
+      const end = offset + length - 1;
+      headers.set("Content-Range", `bytes ${offset}-${end}/${object.size}`);
+    }
+
+    return new Response(object.body, {
+      status: isRange ? 206 : 200,
+      headers,
+    });
+  },
+};

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -2,10 +2,10 @@ name = "demotiles-pmtiles"
 main = "src/index.js"
 compatibility_date = "2024-09-01"
 
-[[r2_buckets]]
-binding = "BUCKET"
-bucket_name = "demotiles-pmtiles"
-
 routes = [
   { pattern = "demotiles.maplibre.org/pmtiles/*", zone_name = "maplibre.org" }
 ]
+
+[[r2_buckets]]
+binding = "BUCKET"
+bucket_name = "demotiles-pmtiles"

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,0 +1,11 @@
+name = "demotiles-pmtiles"
+main = "src/index.js"
+compatibility_date = "2024-09-01"
+
+[[r2_buckets]]
+binding = "BUCKET"
+bucket_name = "demotiles-pmtiles"
+
+routes = [
+  { pattern = "demotiles.maplibre.org/pmtiles/*", zone_name = "maplibre.org" }
+]


### PR DESCRIPTION
## Problem

PMTiles don't render on GitHub Pages when fronted by a CloudFlare CDN.  PMTiles relies on Range requests for tile fetching, but Cloudflare slices HTTP Range requests out of the compressed bytes, returning the wrong Content-Length, a weak ETag, and truncated bodies.

## Solution

A small Cloudflare Worker now intercepts requests to demotiles.maplibre.org/pmtiles/*.pmtiles and serves the files from a private R2 bucket. R2 handles Range requests natively and never transforms content. All other requests under /pmtiles/ (HTML, screenshots, style JSON) pass through to GitHub Pages.

This PR streamlines the README, documents the worker, and adds the worker config.

Closes #35 