### PR TITLE
Fully specify PMTiles URLs and demonstrate runtime source addition

### DIFF
--- a/pmtiles/raster/imagery.html
+++ b/pmtiles/raster/imagery.html
@@ -17,10 +17,42 @@
     const protocol = new pmtiles.Protocol();
     maplibregl.addProtocol('pmtiles', protocol.tile.bind(protocol));
 
-    new maplibregl.Map({
+    const map = new maplibregl.Map({
       container: 'map',
       style: './style-imagery.json',
       hash: true
+    });
+
+    // Terrain source and hillshade layer are added at runtime rather than
+    // declared in the style JSON to demonstrate dynamic source addition.
+    map.on('load', () => {
+      map.addSource('terrain', {
+        type: 'raster-dem',
+        url: 'pmtiles://https://demotiles.maplibre.org/pmtiles/raster/terrain.pmtiles',
+        tileSize: 512,
+        encoding: 'terrarium',
+        maxzoom: 8
+      });
+
+      // Find the first label (symbol) layer so the hillshade can be inserted
+      // beneath it, keeping labels on top without hard-coding a layer id.
+      const firstLabelLayer = map.getStyle().layers.find(
+        (layer) => layer.type === 'symbol'
+      );
+
+      map.addLayer({
+        id: 'terrain-hillshade',
+        type: 'hillshade',
+        source: 'terrain',
+        paint: {
+          'hillshade-illumination-direction': 315,
+          'hillshade-illumination-anchor': 'map',
+          'hillshade-exaggeration': 0.75,
+          'hillshade-shadow-color': 'rgba(34,40,66,0.38)',
+          'hillshade-highlight-color': 'rgba(255,240,214,0.35)',
+          'hillshade-accent-color': 'rgba(12,14,30,0.45)'
+        }
+      }, firstLabelLayer?.id);
     });
   </script>
 </body>

--- a/pmtiles/raster/style-imagery.json
+++ b/pmtiles/raster/style-imagery.json
@@ -14,13 +14,6 @@
       "url": "https://tiles.openstreetmap.us/vector/openmaptiles.json",
       "attribution": "&copy; <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors | <a href='https://tiles.openstreetmap.us/'>OSM US TileService</a>"
     },
-    "terrain": {
-      "type": "raster-dem",
-      "url": "pmtiles://https://demotiles.maplibre.org/pmtiles/raster/terrain.pmtiles",
-      "tileSize": 512,
-      "encoding": "terrarium",
-      "maxzoom": 8
-    },
     "imagery": {
       "type": "raster",
       "url": "pmtiles://https://demotiles.maplibre.org/pmtiles/raster/imagery.pmtiles",
@@ -43,32 +36,6 @@
       "source": "imagery",
       "paint": {
         "raster-opacity": 0.9
-      }
-    },
-    {
-      "id": "terrain-hillshade",
-      "type": "hillshade",
-      "source": "terrain",
-      "paint": {
-        "hillshade-illumination-direction": 315,
-        "hillshade-illumination-anchor": "map",
-        "hillshade-exaggeration": 0.75,
-        "hillshade-shadow-color": "rgba(34,40,66,0.38)",
-        "hillshade-highlight-color": "rgba(255,240,214,0.35)",
-        "hillshade-accent-color": "rgba(12,14,30,0.45)"
-      }
-    },
-    {
-      "id": "terrain-hillshade-ne",
-      "type": "hillshade",
-      "source": "terrain",
-      "paint": {
-        "hillshade-illumination-direction": 45,
-        "hillshade-illumination-anchor": "map",
-        "hillshade-exaggeration": 0.35,
-        "hillshade-shadow-color": "rgba(54,64,96,0.28)",
-        "hillshade-highlight-color": "rgba(255,246,234,0.18)",
-        "hillshade-accent-color": "rgba(26,26,46,0.25)"
       }
     },
     {

--- a/pmtiles/raster/style-imagery.json
+++ b/pmtiles/raster/style-imagery.json
@@ -16,14 +16,14 @@
     },
     "terrain": {
       "type": "raster-dem",
-      "url": "pmtiles://terrain.pmtiles",
+      "url": "pmtiles://https://demotiles.maplibre.org/pmtiles/raster/terrain.pmtiles",
       "tileSize": 512,
       "encoding": "terrarium",
       "maxzoom": 8
     },
     "imagery": {
       "type": "raster",
-      "url": "pmtiles://imagery.pmtiles",
+      "url": "pmtiles://https://demotiles.maplibre.org/pmtiles/raster/imagery.pmtiles",
       "tileSize": 256,
       "maxzoom": 10,
       "attribution": "<a href='https://s2maps.eu'>Sentinel-2 cloudless 2023</a> by <a href='https://eox.at'>EOX</a> (modified Copernicus Sentinel data 2023; CC BY-NC-SA 4.0)"

--- a/pmtiles/raster/style-watercolor.json
+++ b/pmtiles/raster/style-watercolor.json
@@ -16,7 +16,7 @@
     },
     "terrain": {
       "type": "raster-dem",
-      "url": "pmtiles://terrain.pmtiles",
+      "url": "pmtiles://https://demotiles.maplibre.org/pmtiles/raster/terrain.pmtiles",
       "tileSize": 512,
       "encoding": "terrarium",
       "maxzoom": 8,
@@ -24,7 +24,7 @@
     },
     "watercolor": {
       "type": "raster",
-      "url": "pmtiles://watercolor.pmtiles",
+      "url": "pmtiles://https://demotiles.maplibre.org/pmtiles/raster/watercolor.pmtiles",
       "tileSize": 256,
       "maxzoom": 11,
       "attribution": "Watercolor tiles by <a href='https://stamen.com'>Stamen Design</a>, archived by <a href='https://watercolormaps.collection.cooperhewitt.org'>Cooper Hewitt</a>, under <a href='https://creativecommons.org/licenses/by/3.0'>CC BY 3.0</a>."

--- a/pmtiles/vector/style.json
+++ b/pmtiles/vector/style.json
@@ -190,7 +190,7 @@
     "sources": {
         "maplibre": {
             "type": "vector",
-            "url": "pmtiles:///pmtiles/vector/world.pmtiles"
+            "url": "pmtiles://https://demotiles.maplibre.org/pmtiles/vector/world.pmtiles"
         },
         "crimea": {
             "type": "geojson",


### PR DESCRIPTION
I ran into a couple of issues using the PMTiles in the docs for Native:

1. I was referencing the PMTiles demo styles with relative paths, which works in GJ JS, but Native needs absolute paths.

2. I want a good example of what it looks like to add PMTiles as a source; it requires a style to already be defined.

This PR resolves both by (a) fully specifying the URLs in the style JSONs and (b) moving the terrain source and hillshade style layer out of `style-imagery.json` and into `imagery.html` (with some small simplifications).