### PR TITLE
Revert terrain/hillshade refactor from PR #37

### DIFF
--- a/pmtiles/raster/imagery.html
+++ b/pmtiles/raster/imagery.html
@@ -17,42 +17,10 @@
     const protocol = new pmtiles.Protocol();
     maplibregl.addProtocol('pmtiles', protocol.tile.bind(protocol));
 
-    const map = new maplibregl.Map({
+    new maplibregl.Map({
       container: 'map',
       style: './style-imagery.json',
       hash: true
-    });
-
-    // Terrain source and hillshade layer are added at runtime rather than
-    // declared in the style JSON to demonstrate dynamic source addition.
-    map.on('load', () => {
-      map.addSource('terrain', {
-        type: 'raster-dem',
-        url: 'pmtiles://https://demotiles.maplibre.org/pmtiles/raster/terrain.pmtiles',
-        tileSize: 512,
-        encoding: 'terrarium',
-        maxzoom: 8
-      });
-
-      // Find the first label (symbol) layer so the hillshade can be inserted
-      // beneath it, keeping labels on top without hard-coding a layer id.
-      const firstLabelLayer = map.getStyle().layers.find(
-        (layer) => layer.type === 'symbol'
-      );
-
-      map.addLayer({
-        id: 'terrain-hillshade',
-        type: 'hillshade',
-        source: 'terrain',
-        paint: {
-          'hillshade-illumination-direction': 315,
-          'hillshade-illumination-anchor': 'map',
-          'hillshade-exaggeration': 0.75,
-          'hillshade-shadow-color': 'rgba(34,40,66,0.38)',
-          'hillshade-highlight-color': 'rgba(255,240,214,0.35)',
-          'hillshade-accent-color': 'rgba(12,14,30,0.45)'
-        }
-      }, firstLabelLayer?.id);
     });
   </script>
 </body>

--- a/pmtiles/raster/style-imagery.json
+++ b/pmtiles/raster/style-imagery.json
@@ -14,6 +14,13 @@
       "url": "https://tiles.openstreetmap.us/vector/openmaptiles.json",
       "attribution": "&copy; <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors | <a href='https://tiles.openstreetmap.us/'>OSM US TileService</a>"
     },
+    "terrain": {
+      "type": "raster-dem",
+      "url": "pmtiles://https://demotiles.maplibre.org/pmtiles/raster/terrain.pmtiles",
+      "tileSize": 512,
+      "encoding": "terrarium",
+      "maxzoom": 8
+    },
     "imagery": {
       "type": "raster",
       "url": "pmtiles://https://demotiles.maplibre.org/pmtiles/raster/imagery.pmtiles",
@@ -36,6 +43,32 @@
       "source": "imagery",
       "paint": {
         "raster-opacity": 0.9
+      }
+    },
+    {
+      "id": "terrain-hillshade",
+      "type": "hillshade",
+      "source": "terrain",
+      "paint": {
+        "hillshade-illumination-direction": 315,
+        "hillshade-illumination-anchor": "map",
+        "hillshade-exaggeration": 0.75,
+        "hillshade-shadow-color": "rgba(34,40,66,0.38)",
+        "hillshade-highlight-color": "rgba(255,240,214,0.35)",
+        "hillshade-accent-color": "rgba(12,14,30,0.45)"
+      }
+    },
+    {
+      "id": "terrain-hillshade-ne",
+      "type": "hillshade",
+      "source": "terrain",
+      "paint": {
+        "hillshade-illumination-direction": 45,
+        "hillshade-illumination-anchor": "map",
+        "hillshade-exaggeration": 0.35,
+        "hillshade-shadow-color": "rgba(54,64,96,0.28)",
+        "hillshade-highlight-color": "rgba(255,246,234,0.18)",
+        "hillshade-accent-color": "rgba(26,26,46,0.25)"
       }
     },
     {


### PR DESCRIPTION
Reverts af3e688 from #37, which moved the terrain source and hillshade layers from `style-imagery.json` into a runtime `map.on('load')` handler in `imagery.html`.

Restores the original approach: terrain source and both hillshade layers (`terrain-hillshade`, `terrain-hillshade-ne`) declared in the style JSON.

I can't use this in https://github.com/maplibre/maplibre-native/pull/4278 because https://github.com/maplibre/maplibre-native/issues/4357 so reverting as promised.

Tested locally to ensure it still works.